### PR TITLE
Add `read_matrix`

### DIFF
--- a/markdown/Makefile
+++ b/markdown/Makefile
@@ -26,6 +26,7 @@ graphblas.html: $(TEX_SOURCES) $(MD_SOURCES) Makefile
 				 max.md \
 				 min.md \
 				 utilities.md \
+				 read_matrix.md \
 				 concepts.md \
 				 type_traits.md \
 				 matrix_traits.md \
@@ -64,6 +65,7 @@ graphblas.pdf: $(TEX_SOURCES) $(MD_SOURCES) Makefile
 	       max.md \
 	       min.md \
 	       utilities.md \
+	       read_matrix.md \
 	       concepts.md \
 	       type_traits.md \
 	       matrix_traits.md \

--- a/markdown/matrix.md
+++ b/markdown/matrix.md
@@ -61,29 +61,30 @@ Method | Description
 matrix(const Allocator& alloc = Allocator());    (1)
 matrix(grb::index<index_type> shape,
        const Allocator& alloc = Allocator());    (2)
-matrix(std::string file_path,
-       const Allocator& alloc = Allocator());    (3)
+matrix(const matrix& other);                     (3)
+matrix(matrix&& other);                          (4)
 ```
 
 Constructs new `grb::matrix` data structure.
 
 1) Constructs an empty matrix of dimension `0 x 0`.
 2) Constructs an empty matrix of dimension `shape[0] x shape[1]`.
-3) Constructs a matrix with the dimensions and contents of the Matrix Market file at file path `file_path`.
+3) Copy constructor. Constructs a matrix with the dimensions and contents of `other`.
+4) Move constructor. Constructs a matrix with the dimensions and contents of `other` using move semantics.  After the move, `other` is guaranteed to be empty.
 
 ### Parameters
 `shape` - shape of the matrix to be constructed
 
-`file_path` - string containing the file path of the file to be loaded.
+`other` - another matrix to construct the new matrix from
 
 ### Complexity
 1) Constant
 2) Implementation defined
 3) Implementation defined
+4) Implementation defined
 
 ### Exceptions
-(1), (2), and (3) may all throw `std::bad_alloc`.  (3) may also throw the exception `grb::matrix_io::file_error`
-in the case that there is an error opening the file at path `file_path` or reading the file.
+Calls to `Allocator::allocate` may throw.
 
 ## `grb::matrix::size`
 ```cpp

--- a/markdown/read_matrix.md
+++ b/markdown/read_matrix.md
@@ -1,0 +1,45 @@
+## `read_matrix`
+
+
+#### Matrix Times Matrix
+```cpp
+
+template <typename T,
+          std::integral I = std::size_t,
+          typename Hint = grb::sparse,
+          typename Allocator = std::allocator<T>>
+grb::matrix<T, I, Hint, Allocator>
+read_matrix(std::string file_path);
+```
+
+Constructs a new GraphBLAS matrix based on the contents of a file.
+
+## Template Parameters
+`T` - type of scalar values stored in matrix
+
+`I` - type of matrix indices
+
+`Hint` - compile-time hint for backend storage format.
+
+`Allocator` - allocator type
+
+### Parameters
+`file_path` - string holding the file path of the matrix to be read
+
+### Return Value
+
+Returns a GraphBLAS matrix whose dimensions and contents correspond to the
+file located at `file_path`.
+
+### Complexity
+Complexity is implementation-defined.
+
+### Exceptions
+- If the file at `file_path` cannot be read, the exception `grb::matrix_io::file_error` is thrown.
+- If the file at `file_path` is recognized as an unsupported format, the exception `grb::matrix_io::unsupported_file_format` is thrown.
+- Calls to `Allocator::allocate` may throw.
+
+### Notes
+GraphBLAS implementations must define the file formats that they support.  Implementations are strongly encouraged to support the MatrixMarket format.
+
+### Example

--- a/markdown/read_matrix.md
+++ b/markdown/read_matrix.md
@@ -1,7 +1,6 @@
 ## `read_matrix`
 
 
-#### Matrix Times Matrix
 ```cpp
 
 template <typename T,


### PR DESCRIPTION
Remove the `grb::matrix` constructor that takes a `std::string`, replacing it with a new function `read_matrix` that accepts a `std::string` containing a file path and returns a `grb::matrix`.